### PR TITLE
feat: add stored point registry services

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,9 @@ rosidl_generate_interfaces(${PROJECT_NAME}
     "msg/EntityStateArray.msg"
     "msg/SpeedProfileStamped.msg"
     "msg/LaneBoundaries.msg"
+    "srv/CreateStoredPoint.srv"
+    "srv/DeleteStoredPoint.srv"
+    "srv/LookupStoredPoint.srv"
     DEPENDENCIES std_msgs geometry_msgs
 )
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 These contain common message types for all packages in AP1.
 
+This package also contains shared service definitions for cross-team APIs.
+The point-registry workflow for mapping/planning uses:
+
+* `ap1_msgs/srv/CreateStoredPoint`
+* `ap1_msgs/srv/DeleteStoredPoint`
+* `ap1_msgs/srv/LookupStoredPoint`
+
 To use, modify your package.xml and CMakeLists.txt to include the following:
 
 ```xml

--- a/srv/CreateStoredPoint.srv
+++ b/srv/CreateStoredPoint.srv
@@ -1,0 +1,3 @@
+geometry_msgs/Point point
+---
+uint32 id

--- a/srv/DeleteStoredPoint.srv
+++ b/srv/DeleteStoredPoint.srv
@@ -1,0 +1,3 @@
+uint32 id
+---
+bool deleted

--- a/srv/LookupStoredPoint.srv
+++ b/srv/LookupStoredPoint.srv
@@ -1,0 +1,4 @@
+uint32 id
+---
+bool found
+geometry_msgs/Point point


### PR DESCRIPTION
## Summary
- add shared service definitions for creating, deleting, and looking up stored points
- register the new service interfaces in the ap1_msgs build
- document the point registry API in the package README

## Testing
- git diff --check